### PR TITLE
fix: update Goerli references to Sepolia

### DIFF
--- a/config/agent-heroku.yml
+++ b/config/agent-heroku.yml
@@ -49,8 +49,8 @@ ethr-did-resolver:
           rpcUrl: https://ropsten.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
         - name: kovan
           rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
-        - name: goerli
-          rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+        - name: sepolia
+          rpcUrl: https://sepolia.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
         - name: private
           rpcUrl: http://localhost:8545/
           registry: '0x05cc574b19a3c11308f761b3d7263bd8608bc532'
@@ -138,12 +138,12 @@ agent:
                       rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
                       gas: 1000001
                       ttl: 31104001
-                did:ethr:goerli:
+                did:ethr:sepolia:
                   $require: '@veramo/did-provider-ethr#EthrDIDProvider'
                   $args:
                     - defaultKms: local
-                      network: goerli
-                      rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+                      network: sepolia
+                      rpcUrl: https://sepolia.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
                       gas: 1000001
                       ttl: 31104001
                 did:web:

--- a/config/agent-local.yml
+++ b/config/agent-local.yml
@@ -61,8 +61,8 @@ ethr-did-resolver:
           rpcUrl: https://ropsten.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
         - name: kovan
           rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
-        - name: goerli
-          rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+        - name: sepolia
+          rpcUrl: https://sepolia.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
         - name: private
           rpcUrl: http://localhost:8545/
           registry: '0x05cc574b19a3c11308f761b3d7263bd8608bc532'
@@ -150,12 +150,12 @@ agent:
                       rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
                       gas: 1000001
                       ttl: 31104001
-                did:ethr:goerli:
+                did:ethr:sepolia:
                   $require: '@veramo/did-provider-ethr#EthrDIDProvider'
                   $args:
                     - defaultKms: local
-                      network: goerli
-                      rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+                      network: sepolia
+                      rpcUrl: https://sepolia.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
                       gas: 1000001
                       ttl: 31104001
                 did:web:


### PR DESCRIPTION
The project was using outdated references to the Goerli testnet, which has been deprecated with the Infura API. This commit updates these references to the Sepolia testnet to ensure the network functionality is not interrupted.